### PR TITLE
Add dash shell compatibility testing

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,21 +22,39 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shell: [bash, dash]
+        include:
+          - shell: bash
+            install: ""
+            exec: "bash"
+          - shell: dash
+            install: "dash"
+            exec: "dash"
+          - shell: ash
+            install: "ash"
+            exec: "ash"
+          - shell: zsh
+            install: "zsh"
+            exec: "zsh"
+          - shell: ksh
+            install: "ksh"
+            exec: "ksh"
+          - shell: busybox-sh
+            install: "busybox"
+            exec: "busybox sh"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     
-    - name: Install dash
-      run: sudo apt-get update && sudo apt-get install -y dash
-      if: matrix.shell == 'dash'
+    - name: Install shell
+      run: sudo apt-get update && sudo apt-get install -y ${{ matrix.install }}
+      if: matrix.install != ''
     
     - name: Test script with ${{ matrix.shell }}
       run: |
         # Set non-interactive mode and test script
         export ES_EXISTING_FOLDER_ACTION=d
         export ES_FORCE_INSTALL=1
-        ${{ matrix.shell }} effective.sh
+        ${{ matrix.exec }} effective.sh
       env:
         ES_DEBUG: 1
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -57,4 +57,12 @@ jobs:
         ${{ matrix.exec }} effective.sh
       env:
         ES_DEBUG: 1
+    
+    - name: Verify installation
+      run: |
+        echo "Checking installation results..."
+        ls -la ~/effective-shell/ || echo "❌ effective-shell directory not found"
+        [ -f ~/effective-shell/.version.txt ] && echo "✅ Version file exists: $(cat ~/effective-shell/.version.txt)" || echo "❌ Version file missing"
+        [ -d ~/effective-shell ] && echo "✅ Directory size: $(du -sh ~/effective-shell/)" || echo "❌ Directory missing"
+        find ~/effective-shell -type f | head -10 || echo "❌ No files found"
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,3 +17,26 @@ jobs:
     # Ensure we can build.
     - name: Build
       run: make build
+
+  shell-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shell: [bash, dash]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    - name: Install dash
+      run: sudo apt-get update && sudo apt-get install -y dash
+      if: matrix.shell == 'dash'
+    
+    - name: Test script with ${{ matrix.shell }}
+      run: |
+        # Set non-interactive mode and test script
+        export ES_EXISTING_FOLDER_ACTION=d
+        export ES_FORCE_INSTALL=1
+        ${{ matrix.shell }} effective.sh
+      env:
+        ES_DEBUG: 1
+

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is the install script for the https://effective-shell.com samples. This rep
 
 To install the [Effective Shell](https://effective-shell.com) samples, just run:
 
-```sh
-curl effective.sh | sh
+```bash
+curl -fsSL effective.sh | bash
 ```
 
 That's it! This will download the Effective Shell samples to the folder:

--- a/effective.sh
+++ b/effective.sh
@@ -64,8 +64,8 @@ fi
 
     # Print a message with a hint it's from the effective shell script.
     es_echo () {
-      local green='\e[0;32m'
-      local reset='\e[0m'
+      green='\e[0;32m'
+      reset='\e[0m'
       command printf "${green}effective-shell${reset}: %s\\n" "$*" 2>/dev/null
     }
 

--- a/effective.sh
+++ b/effective.sh
@@ -28,7 +28,12 @@
 
 # Bail on errors.
 set -e
-set -o pipefail
+# Only set pipefail in bash - dash and other POSIX shells don't support this option.
+# This provides extra safety in bash while maintaining compatibility with Linux Mint
+# and other systems where /bin/sh points to dash.
+if [ -n "$BASH_VERSION" ]; then
+    set -o pipefail
+fi
 
 # Uncomment the below if you want to enable tracing to debug the script.
 # set -x


### PR DESCRIPTION
## Summary
- Add matrix strategy to test installer script with both bash and dash shells
- Configure non-interactive mode to avoid prompts during CI
- Install dash explicitly on Ubuntu runners
- This should reproduce the Linux Mint compatibility issues reported in #35

## Test plan
- [ ] Verify bash tests still pass
- [ ] Confirm dash tests fail with the expected `set -o pipefail` error
- [ ] Use results to guide shell compatibility fixes